### PR TITLE
Improve error handling for OpenAI JSON parsing

### DIFF
--- a/server/ai-pdf-controller-new.ts
+++ b/server/ai-pdf-controller-new.ts
@@ -180,7 +180,16 @@ Retorne apenas um JSON válido com os dados extraídos:`;
       max_tokens: 4000
     });
 
-    const extractedData = JSON.parse(response.choices[0].message.content || '{}');
+    let extractedData;
+    try {
+      extractedData = JSON.parse(response.choices[0].message.content || '{}');
+    } catch (parseErr) {
+      const raw = response.choices[0].message.content || '';
+      const truncated = raw.slice(0, 200);
+      console.error('Failed to parse JSON from OpenAI:', truncated);
+      throw new Error(`Invalid JSON from OpenAI: ${truncated}`);
+    }
+
     console.log('Dados extraídos pela OpenAI:', extractedData);
 
     return extractedData;

--- a/server/ai-pdf-controller.ts
+++ b/server/ai-pdf-controller.ts
@@ -237,7 +237,15 @@ Responda apenas com o JSON válido contendo os dados extraídos:`;
       cleanContent = cleanContent.replace(/```\s*/, '').replace(/```\s*$/, '');
     }
     
-    const aiExtractedData = JSON.parse(cleanContent);
+    let aiExtractedData;
+    try {
+      aiExtractedData = JSON.parse(cleanContent);
+    } catch (parseErr) {
+      const raw = responseContent.slice(0, 200);
+      console.error('Failed to parse JSON from OpenAI:', raw);
+      throw new Error(`Invalid JSON from OpenAI: ${raw}`);
+    }
+
     console.log('=== DADOS EXTRAÍDOS PELA OPENAI ===');
     console.log(JSON.stringify(aiExtractedData, null, 2));
     

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1358,7 +1358,18 @@ Responda apenas com o JSON válido contendo os dados extraídos:`;
       }
 
       const result = await response.json();
-      const extractedData = JSON.parse(result.choices[0].message.content);
+      let extractedData;
+      try {
+        extractedData = JSON.parse(result.choices[0].message.content);
+      } catch (parseErr) {
+        const raw = result.choices[0].message.content.slice(0, 200);
+        console.error('Failed to parse JSON from OpenAI:', raw);
+        return res.status(500).json({
+          success: false,
+          error: `Invalid JSON from OpenAI: ${raw}`,
+          apiKeyConfigured: !!process.env.OPENAI_API_KEY
+        });
+      }
 
       console.log('OpenAI Response:', extractedData);
 


### PR DESCRIPTION
## Summary
- guard against malformed JSON returned from OpenAI
- log raw OpenAI response when parsing fails and return it in the error message

## Testing
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867d3732d9c832fa227f80446900620